### PR TITLE
CN recognized regexp changed

### DIFF
--- a/ovpncncheck.py
+++ b/ovpncncheck.py
@@ -70,7 +70,7 @@ def main():
         # If so, parse out the common name substring in
         # the X509 subject string.
 
-        found = re.compile(r"/CN=(?P<cn>[^/]+)").search(x509)
+        found = re.compile(r" CN=(?P<cn>[^\,]+)").search(x509)
         if found:
             # Accept the connection if the X509 common name
             # string matches a regex


### PR DESCRIPTION
Becouse x509 variable is of the shape:

... L=Someware, O=Some org, CN=the-name, name=some-name

then regexp should be changed (I guess OpenVPN since 2.3.? changed the
shape of 3rd parameter passed to the tls-verify script).